### PR TITLE
Fixed readMultipleEncoderRegisters

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,7 @@ build_flags = -fmax-errors=5
   -ggdb
   #-D USE_STDPERIPH_DRIVER
   #-D STM32F103xB
-  -D HSE_VALUE=14187200U
+  #-D HSE_VALUE=14187200U
 
   #-I src
   -I src/lib/CAN

--- a/src/hardware/encoder.h
+++ b/src/hardware/encoder.h
@@ -5,10 +5,6 @@
 #include "Arduino.h"
 #include "config.h"
 
-// Defines
-#define SPI_TX_OFF   {GPIOA->CRL&=0x0FFFFFFF;GPIOA->CRL|=0x40000000;}
-#define SPI_TX_ON    {GPIOA->CRL&=0x0FFFFFFF;GPIOA->CRL|=0xB0000000;}
-
 // Register locations (reading)
 #define ENCODER_READ_COMMAND   0x8000 // 8000
 #define ENCODER_STATUS_REG (0x0000U) // Same as base

--- a/src/user/config.h
+++ b/src/user/config.h
@@ -13,7 +13,7 @@
 #define BOARD_VOLTAGE 3.3 // The voltage of the main processor
 //#define TEST_FLASH
 
-#define ENCODER_SPEED_ESTIMATION // If encoder estimation should be used
+//#define ENCODER_SPEED_ESTIMATION // If encoder estimation should be used
 #ifdef ENCODER_SPEED_ESTIMATION
     #define SPD_EST_MIN_INTERVAL 250 // The minimum sampling interval (ms). Increase to get more steady readings at the cost of accuracy
 #endif


### PR DESCRIPTION
Also removed some debug statements and optimized code.

`double getEncoderSpeed()` still does not work, I wonder how the original by Infineon is supposed to work. Here (https://github.com/Infineon/TLE5012-Magnetic-Angle-Sensor/blob/77b64e2817fe84fc2df79394474dc7932383ff0f/src/corelib/TLE5012b.cpp#L509) they read data from memory outside the buffer, which can be anything.
The register values returned by `readMultipleEncoderRegisters` are the same as from `readEncoderRegister`, so that is fixed. `memcpy` swapped high and low bytes so I wrote a loop.