### PR TITLE
GPIO speed investigation

### DIFF
--- a/src/hardware/encoder.cpp
+++ b/src/hardware/encoder.cpp
@@ -181,7 +181,7 @@ void initEncoder() {
 
     // Set the chip select pin high, disabling the encoder's communication
     pinMode(ENCODER_CS_PIN, OUTPUT);
-    digitalWrite(ENCODER_CS_PIN, HIGH);
+    GPIO_WRITE(ENCODER_CS_PIN, HIGH);
 
     // Reset the encoder's firmware
     //writeToEncoderRegister(ENCODER_ACT_STATUS_REG, 0x401);
@@ -225,7 +225,7 @@ errorTypes readEncoderRegister(uint16_t registerAddress, uint16_t &data) {
     errorTypes error = NO_ERROR;
 
     // Pull CS low to select encoder
-    digitalWrite(ENCODER_CS_PIN, LOW);
+    GPIO_WRITE(ENCODER_CS_PIN, LOW);
 
     // Add read bit to address
     registerAddress |= ENCODER_READ_COMMAND;
@@ -260,7 +260,7 @@ errorTypes readEncoderRegister(uint16_t registerAddress, uint16_t &data) {
     HAL_GPIO_Init(GPIOA, &GPIO_InitStructure);
 
     // Deselect encoder
-    digitalWrite(ENCODER_CS_PIN, HIGH);
+    GPIO_WRITE(ENCODER_CS_PIN, HIGH);
 
     // Set data in the specified location (depending on errors)
     if (error == NO_ERROR) {
@@ -288,7 +288,7 @@ void readMultipleEncoderRegisters(uint16_t registerAddress, uint16_t* data, uint
     disableInterrupts();
 
     // Pull CS low to select encoder
-    digitalWriteFast(ENCODER_CS_PIN, LOW);
+    GPIO_WRITE(ENCODER_CS_PIN, LOW);
 
     // Setup TX and RX buffers
     registerAddress |= ENCODER_READ_COMMAND + dataLength;
@@ -320,7 +320,7 @@ void readMultipleEncoderRegisters(uint16_t registerAddress, uint16_t* data, uint
     HAL_GPIO_Init(GPIOA, &GPIO_InitStructure);
 
     // Deselect encoder
-    digitalWriteFast(ENCODER_CS_PIN, HIGH);
+    GPIO_WRITE(ENCODER_CS_PIN, HIGH);
 
     // All done, good to re-enable interrupts
     enableInterrupts();
@@ -335,7 +335,7 @@ void writeToEncoderRegister(uint16_t registerAddress, uint16_t data) {
     disableInterrupts();
 
     // Pull CS low to select encoder
-    digitalWriteFast(ENCODER_CS_PIN, LOW);
+    GPIO_WRITE(ENCODER_CS_PIN, LOW);
 
     // Setup TX and RX buffers
     registerAddress |= ENCODER_WRITE_COMMAND + 1;
@@ -359,7 +359,7 @@ void writeToEncoderRegister(uint16_t registerAddress, uint16_t data) {
     HAL_GPIO_Init(GPIOA, &GPIO_InitStructure);
 
     // Deselect encoder
-    digitalWriteFast(ENCODER_CS_PIN, HIGH);
+    GPIO_WRITE(ENCODER_CS_PIN, HIGH);
 
     // All work is done, re-enable the interrupts
     enableInterrupts();

--- a/src/hardware/led.cpp
+++ b/src/hardware/led.cpp
@@ -18,5 +18,5 @@ void initLED() {
 
 // Sets the state of the LED. On is true, off is false
 void setLED(uint8_t state) {
-    LED_PIN_OBJ = state;
+    GPIO_WRITE(LED_PIN_OBJ, state);
 }

--- a/src/hardware/led.cpp
+++ b/src/hardware/led.cpp
@@ -2,9 +2,11 @@
 
 // Function to setup the red LED
 void initLED() {
+
     // Initialization structure
     GPIO_InitTypeDef GPIO_InitStructure;
     
+    // Enable GPIOC clock
     __HAL_RCC_GPIOC_CLK_ENABLE();
 
     // Setup pin C13
@@ -13,10 +15,4 @@ void initLED() {
     GPIO_InitStructure.Pull = GPIO_NOPULL;
     GPIO_InitStructure.Speed = GPIO_SPEED_FREQ_HIGH;
     HAL_GPIO_Init(GPIOC, &GPIO_InitStructure);
-}
-
-
-// Sets the state of the LED. On is true, off is false
-void setLED(uint8_t state) {
-    GPIO_WRITE(LED_PIN_OBJ, state);
 }

--- a/src/hardware/led.h
+++ b/src/hardware/led.h
@@ -5,11 +5,7 @@
 #include "Arduino.h"
 #include "config.h"
 
-// Main LED object
-#define LED_PIN_OBJ output(GPIOC_BASE, 13)
-
 // Functions
 void initLED();
-void setLED(uint8_t state);
 
 #endif

--- a/src/hardware/motor.cpp
+++ b/src/hardware/motor.cpp
@@ -15,10 +15,10 @@ StepperMotor::StepperMotor() {
     pinMode(COIL_POWER_OUTPUT_PINS[B], OUTPUT);
 
     // Setup the coil direction pins 
-    pinMode(COIL_A_DIR_1_ARDUINO_PIN, OUTPUT);
-    pinMode(COIL_A_DIR_2_ARDUINO_PIN, OUTPUT);
-    pinMode(COIL_B_DIR_1_ARDUINO_PIN, OUTPUT);
-    pinMode(COIL_B_DIR_2_ARDUINO_PIN, OUTPUT);
+    pinMode(COIL_A_DIR_1_PIN, OUTPUT);
+    pinMode(COIL_A_DIR_2_PIN, OUTPUT);
+    pinMode(COIL_B_DIR_1_PIN, OUTPUT);
+    pinMode(COIL_B_DIR_2_PIN, OUTPUT);
 
     // Configure the PWM current output pins
     this -> PWMCurrentPinInfo[A] = analogSetup(COIL_POWER_OUTPUT_PINS[A], MOTOR_PWM_FREQ, 0);
@@ -378,20 +378,20 @@ void StepperMotor::setCoilA(COIL_STATE desiredState, uint16_t current) {
 
         // Decide the state of the direction pins
         if (desiredState == FORWARD) {
-            COIL_A_DIR_1_PIN = 1;
-            COIL_A_DIR_2_PIN = 0;
+            GPIO_WRITE(COIL_A_DIR_1_PIN, HIGH);
+            GPIO_WRITE(COIL_A_DIR_2_PIN, LOW);
         }
         else if (desiredState == BACKWARD) {
-            COIL_A_DIR_1_PIN = 0;
-            COIL_A_DIR_2_PIN = 1;
+            GPIO_WRITE(COIL_A_DIR_1_PIN, LOW);
+            GPIO_WRITE(COIL_A_DIR_2_PIN, HIGH);
         }
         else if (desiredState == BRAKE) {
-            COIL_A_DIR_1_PIN = 1;
-            COIL_A_DIR_2_PIN = 1;
+            GPIO_WRITE(COIL_A_DIR_1_PIN, HIGH);
+            GPIO_WRITE(COIL_A_DIR_2_PIN, HIGH);
         }
         else if (desiredState == COAST) {
-            COIL_A_DIR_1_PIN = 0;
-            COIL_A_DIR_2_PIN = 0;
+            GPIO_WRITE(COIL_A_DIR_1_PIN, LOW);
+            GPIO_WRITE(COIL_A_DIR_2_PIN, LOW);
         }
         
         // Update the previous state of the coil with the new one
@@ -419,21 +419,22 @@ void StepperMotor::setCoilB(COIL_STATE desiredState, uint16_t current) {
         analogSet(&PWMCurrentPinInfo[B], 0);
 
         // Decide the state of the direction pins
+        // Decide the state of the direction pins
         if (desiredState == FORWARD) {
-            COIL_B_DIR_1_PIN = 1;
-            COIL_B_DIR_2_PIN = 0;
+            GPIO_WRITE(COIL_B_DIR_1_PIN, HIGH);
+            GPIO_WRITE(COIL_B_DIR_2_PIN, LOW);
         }
         else if (desiredState == BACKWARD) {
-            COIL_B_DIR_1_PIN = 0;
-            COIL_B_DIR_2_PIN = 1;
+            GPIO_WRITE(COIL_B_DIR_1_PIN, LOW);
+            GPIO_WRITE(COIL_B_DIR_2_PIN, HIGH);
         }
         else if (desiredState == BRAKE) {
-            COIL_B_DIR_1_PIN = 1;
-            COIL_B_DIR_2_PIN = 1;
+            GPIO_WRITE(COIL_B_DIR_1_PIN, HIGH);
+            GPIO_WRITE(COIL_B_DIR_2_PIN, HIGH);
         }
         else if (desiredState == COAST) {
-            COIL_B_DIR_1_PIN = 0;
-            COIL_B_DIR_2_PIN = 0;
+            GPIO_WRITE(COIL_B_DIR_1_PIN, LOW);
+            GPIO_WRITE(COIL_B_DIR_2_PIN, LOW);
         }
         
         // Update the previous state of the coil with the new one

--- a/src/hardware/motor.cpp
+++ b/src/hardware/motor.cpp
@@ -272,6 +272,14 @@ void StepperMotor::step(STEP_DIR dir, bool useMultiplier, bool updateDesiredAngl
 // Sets the coils of the motor based on the angle (angle should be in degrees)
 void StepperMotor::driveCoils(float degAngle, STEP_DIR direction) {
 
+    if (degAngle < 0) {
+        degAngle += round(abs(degAngle) / 360) * 360;
+    }
+    else if ( degAngle > 360)
+    {
+        degAngle -= round(degAngle / 360) * 360;
+    }
+            
     // Constrain the set angle to between 0 and 360
     while (degAngle < 0 || degAngle > 360) {
         

--- a/src/hardware/oled.cpp
+++ b/src/hardware/oled.cpp
@@ -577,7 +577,7 @@ void initOLED() {
     // Write that pins B12-15 should be general purpose outputs
   	GPIOB -> CRH |= 0b00110011001100110000000000000000;
 
-	OLED_RST_PIN = 1;
+	GPIO_WRITE(OLED_RST_PIN, HIGH);
 	writeOLEDByte(0xAE, COMMAND);//
 	writeOLEDByte(0xD5, COMMAND);//
 	writeOLEDByte(80,   COMMAND);  //[3:0],;[7:4],
@@ -615,36 +615,36 @@ void initOLED() {
 void writeOLEDByte(uint8_t data, OLED_MODE mode) {
 
     // Write the current mode and enable the screen's communcation
-	OLED_RS_PIN = (uint8_t)mode;
-	OLED_CS_PIN = 0;
+	GPIO_WRITE(OLED_RS_PIN, (uint8_t)mode);
+	GPIO_WRITE(OLED_CS_PIN, LOW);
 
     // Write each bit of the byte
 	for(uint8_t i = 0; i < 8; i++) {
 
         // Prevent the screen from reading the data in
-		OLED_SCLK_PIN = 0;
+        GPIO_WRITE(OLED_SCLK_PIN, LOW);
 
         // If the bit is 1 (true)
 		if(data & 0x80) {
 
             // Write true
-            OLED_SDIN_PIN = 1;
+            GPIO_WRITE(OLED_SDIN_PIN, HIGH);
         }
 		else {
             // Write false
-            OLED_SDIN_PIN = 0;
+            GPIO_WRITE(OLED_SDIN_PIN, LOW);
         }
 
         // Signal that the data needs to be sampled again
-		OLED_SCLK_PIN = 1;
+		GPIO_WRITE(OLED_SCLK_PIN, HIGH);
 
         // Shift all of the bits so the next will be read
 		data <<= 1;
 	}
 
     // Disable the screen's communication
-	OLED_CS_PIN = 1;
-	OLED_RS_PIN = 1;
+    GPIO_WRITE(OLED_CS_PIN, HIGH);
+    GPIO_WRITE(OLED_RS_PIN, HIGH);
 }
 
 

--- a/src/hardware/timers.cpp
+++ b/src/hardware/timers.cpp
@@ -185,11 +185,11 @@ void correctMotor() {
             // Shut off the StallGuard pin just in case
             // (No need to check if the pin is valid, the pin will never be set up if it isn't valid)
             #ifdef STALLFAULT_PIN
-                digitalWriteFast(STALLFAULT_PIN, LOW);
+                GPIO_WRITE(STALLFAULT_PIN, LOW);
             #endif
 
             // Fix the LED pin
-            setLED(LOW);
+            GPIO_WRITE(LED_PIN, LOW);
         #endif
     }
     else {
@@ -260,11 +260,11 @@ void correctMotor() {
                     }
 
                     // The maximum count has been exceeded, trigger an endstop pulse
-                    digitalWriteFast(STALLFAULT_PIN, HIGH);
+                    GPIO_WRITE(STALLFAULT_PIN, HIGH);
                     #endif
 
                     // Also give an indicator on the LED
-                    setLED(HIGH);
+                    GPIO_WRITE(LED_PIN, HIGH);
                 }
                 else {
                     // Just count up, motor is out of position but not out of faults
@@ -292,12 +292,12 @@ void correctMotor() {
             // No need to check the validity of the pin here, it wouldn't be setup if it wasn't valid
             #ifdef STALLFAULT_PIN
             if (stallFaultPinSetup) {
-                digitalWriteFast(STALLFAULT_PIN, LOW);
+                GPIO_WRITE(STALLFAULT_PIN, LOW);
             }
             #endif
 
             // Also toggle the LED for visual purposes
-            setLED(LOW);
+            GPIO_WRITE(LED_PIN, LOW);
             
             #endif // ! ENABLE_STALLFAULT
         }

--- a/src/user/cube.cpp
+++ b/src/user/cube.cpp
@@ -14,6 +14,22 @@ void MCO_GPIO_Init(void)
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
   HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 }
+#elif defined(CHECK_GPIO_OUTPUT_SWITCHING)
+void PA_8_GPIO_Init(void)
+{
+  // Initialization structure
+  GPIO_InitTypeDef GPIO_InitStruct = {0};
+
+  /* GPIO Ports Clock Enable */
+  __HAL_RCC_GPIOA_CLK_ENABLE();
+
+  /*Configure GPIO pin : PA8 */
+  GPIO_InitStruct.Pin = GPIO_PIN_8;
+  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+  GPIO_InitStruct.Pull = GPIO_NOPULL;
+  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+}
 #endif
 
 
@@ -36,7 +52,7 @@ void SystemClock_Config_HSE_16M_SYSCLK_72M(void) {
   RCC_OscInitStruct.PLL.PLLMUL = RCC_PLL_MUL9;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
   {
-   //Error_Handler();
+    //Error_Handler();
   }
   /** Initializes the CPU, AHB and APB buses clocks
   */
@@ -49,7 +65,7 @@ void SystemClock_Config_HSE_16M_SYSCLK_72M(void) {
 
   if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK)
   {
-   //Error_Handler();
+    //Error_Handler();
   }
   #ifdef CHECK_MCO_OUTPUT
     HAL_RCC_MCOConfig(RCC_MCO, RCC_MCO1SOURCE_HSE, RCC_MCODIV_1);
@@ -76,7 +92,7 @@ void SystemClock_Config_HSE_8M_SYSCLK_72M(void) {
   RCC_OscInitStruct.PLL.PLLMUL = RCC_PLL_MUL9;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
   {
-   //Error_Handler();
+    //Error_Handler();
   }
   /** Initializes the CPU, AHB and APB buses clocks
   */
@@ -89,7 +105,7 @@ void SystemClock_Config_HSE_8M_SYSCLK_72M(void) {
 
   if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK)
   {
-   //Error_Handler();
+    //Error_Handler();
   }
 
   #ifdef CHECK_MCO_OUTPUT
@@ -116,7 +132,7 @@ void SystemClock_Config_HSI_8M_SYSCLK_64M(void) {
   RCC_OscInitStruct.PLL.PLLMUL = RCC_PLL_MUL16;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
   {
-   //Error_Handler();
+    //Error_Handler();
   }
   /** Initializes the CPU, AHB and APB buses clocks
   */
@@ -129,7 +145,7 @@ void SystemClock_Config_HSI_8M_SYSCLK_64M(void) {
 
   if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK)
   {
-   //Error_Handler();
+    //Error_Handler();
   }
 
   #ifdef CHECK_MCO_OUTPUT

--- a/src/user/cube.h
+++ b/src/user/cube.h
@@ -2,6 +2,7 @@
 #define __CUBE_H
 
 void MCO_GPIO_Init(void);
+void PA_8_GPIO_Init(void);
 void SystemClock_Config_HSE_16M_SYSCLK_72M(void);
 void SystemClock_Config_HSE_8M_SYSCLK_72M(void);
 void SystemClock_Config_HSI_8M_SYSCLK_64M(void);

--- a/src/user/main.cpp
+++ b/src/user/main.cpp
@@ -127,15 +127,6 @@ void setup() {
             GPIO_WRITE(PA_8, LOW);
             GPIO_WRITE(PA_8, LOW);
             GPIO_WRITE(PA_8, LOW);
-
-            // SystemClock_Config_HSE_8M_SYSCLK_72M() is selected:
-            //           | GPIO_FUNCTION | bazed on 
-            //  14,4 kHz | 0             | digitalWrite()
-            //  81.4 kHz | 1             | digitalWriteFast()
-            //  1.64 MHz | 2             | digitalWriteFaster()
-            //  1.67 MHz | 3             | digitalWriteFastest()
-            // 600.1 kHz | 4             | output()
-            // 163.3.kHz | 5             | HAL_GPIO_WritePin()
         }
     #endif
 
@@ -290,8 +281,7 @@ void overclock(uint32_t PLLMultiplier) {
     HAL_RCC_OscConfig(&RCC_OscInitStruct);
 
     // Wait for the PLL to be configured
-    while(!(RCC_CR_PLLRDY & RCC -> CR))
-        ; // 
+    while(!(RCC_CR_PLLRDY & RCC -> CR)); // 
 
     // Use the PLL as the system clock
     RCC -> CFGR |= RCC_SYSCLKSOURCE_PLLCLK;
@@ -304,8 +294,8 @@ void overclock(uint32_t PLLMultiplier) {
 
 // ! Only here for testing
 void blink() {
-    digitalWriteFast(LED_PIN, HIGH);
+    GPIO_WRITE(LED_PIN, HIGH);
     delay(500);
-    digitalWriteFast(LED_PIN, LOW);
+    GPIO_WRITE(LED_PIN, LOW);
     delay(500);
 }

--- a/src/user/main.cpp
+++ b/src/user/main.cpp
@@ -99,6 +99,46 @@ void setup() {
         initLED();
     #endif
 
+    #ifdef CHECK_MCO_OUTPUT
+        MCO_GPIO_Init();
+    #endif
+    
+    #ifdef CHECK_GPIO_OUTPUT_SWITCHING
+        PA_8_GPIO_Init();
+        while(true) {
+            GPIO_WRITE(PA_8, HIGH);
+            GPIO_WRITE(PA_8, HIGH);
+            GPIO_WRITE(PA_8, HIGH);
+            GPIO_WRITE(PA_8, HIGH);
+            GPIO_WRITE(PA_8, HIGH);
+            GPIO_WRITE(PA_8, HIGH);
+            GPIO_WRITE(PA_8, HIGH);
+            GPIO_WRITE(PA_8, HIGH);
+            GPIO_WRITE(PA_8, HIGH);
+            GPIO_WRITE(PA_8, HIGH);
+
+            GPIO_WRITE(PA_8, LOW);
+            GPIO_WRITE(PA_8, LOW);
+            GPIO_WRITE(PA_8, LOW);
+            GPIO_WRITE(PA_8, LOW);
+            GPIO_WRITE(PA_8, LOW);
+            GPIO_WRITE(PA_8, LOW);
+            GPIO_WRITE(PA_8, LOW);
+            GPIO_WRITE(PA_8, LOW);
+            GPIO_WRITE(PA_8, LOW);
+            GPIO_WRITE(PA_8, LOW);
+
+            // SystemClock_Config_HSE_8M_SYSCLK_72M() is selected:
+            //           | GPIO_FUNCTION | bazed on 
+            //  14,4 kHz | 0             | digitalWrite()
+            //  81.4 kHz | 1             | digitalWriteFast()
+            //  1.64 MHz | 2             | digitalWriteFaster()
+            //  1.67 MHz | 3             | digitalWriteFastest()
+            // 600.1 kHz | 4             | output()
+            // 163.3.kHz | 5             | HAL_GPIO_WritePin()
+        }
+    #endif
+
     // Test the flash if specified
     //#ifdef TEST_FLASH
     //    flash_test();
@@ -250,7 +290,8 @@ void overclock(uint32_t PLLMultiplier) {
     HAL_RCC_OscConfig(&RCC_OscInitStruct);
 
     // Wait for the PLL to be configured
-    while(!(RCC_CR_PLLRDY & RCC -> CR));
+    while(!(RCC_CR_PLLRDY & RCC -> CR))
+        ; // 
 
     // Use the PLL as the system clock
     RCC -> CFGR |= RCC_SYSCLKSOURCE_PLLCLK;

--- a/src/user/main.h
+++ b/src/user/main.h
@@ -1,10 +1,10 @@
 #ifndef __MAIN_H__
 #define __MAIN_H__
 
-#include "motor.h"
 #include "Arduino.h"
 #include "stdint.h"
 #include "config.h"
+#include "motor.h"
 
 //extern void Output(int32_t theta,uint8_t effort);
 //extern uint16_t ReadAngle(void);


### PR DESCRIPTION
```
            // SystemClock_Config_HSE_8M_SYSCLK_72M() is selected:
            //           | GPIO_FUNCTION | bazed on 
            //  14,4 kHz | 0             | digitalWrite()
            //  81.4 kHz | 1             | digitalWriteFast()
            //  1.64 MHz | 2             | digitalWriteFaster()
            //  1.67 MHz | 3             | digitalWriteFastest()
            // 600.1 kHz | 4             | output()
            // 163.3.kHz | 5             | HAL_GPIO_WritePin()
```
I propose always using the GPIO WRITE () macro to set the pin level in the project.
This allows to select an other GPIO_FUNCTION without changing many of the original files in future.
Like in led.cpp
