### PR TITLE
Fix initialization of input pins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 .vscode/launch.json
 .vscode/ipch
 STM32CubeMX/STM32F103CBTx_LQFP48/Core*
+STM32CubeMX/STM32F103CBTx_LQFP48/Drivers*
+STM32CubeMX/STM32F103CBTx_LQFP48/EWARM*
 STM32CubeMX/STM32F103CBTx_LQFP48/.mxproject
 img/
 .DS_Store

--- a/src/hardware/encoder.cpp
+++ b/src/hardware/encoder.cpp
@@ -200,7 +200,7 @@ void initEncoder() {
     }
 
     // Set the offsets
-    //startupAngleOffset = getAngle();
+    startupAngleOffset = getAngle();
     startupAngleRevOffset = getAbsoluteRev();
 
     // Set the correct starting values for the estimation if using estimation
@@ -310,7 +310,7 @@ void readMultipleEncoderRegisters(uint16_t registerAddress, uint16_t* data, uint
         txbuf[i] = 0xFF;
     }
     HAL_SPI_TransmitReceive(&spiConfig, txbuf, rxbuf, dataLength * 2, 100);
-    
+
     // Write the received data into the array
     for (uint8_t i = 0; i < dataLength; i++) {
         data[i] = rxbuf[i * 2] << 8 | rxbuf[i * 2 + 1];
@@ -370,7 +370,7 @@ void writeToEncoderRegister(uint16_t registerAddress, uint16_t data) {
 // Checks the encoder's response for any errors
 // Warning: this function cannot be interrupted, so make sure that it is called in a function that disables interrupts
 errorTypes checkSafety(uint16_t safety, uint16_t command, uint16_t* readreg, uint16_t length) {
-	
+
     // A final accumulator for there was an error
     errorTypes error;
 
@@ -737,7 +737,7 @@ double getEncoderTemp() {
 
     // All important work is done
     enableInterrupts();
-    
+
     // Return the temperature
     return temp;
 }
@@ -752,7 +752,7 @@ double getAbsoluteRev() {
     // Create an accumulator for the raw data and converted data
     uint16_t rawData;
     int16_t convertedData;
-    
+
     // Loop continuously until there is no error
     while (readEncoderRegister(ENCODER_ANGLE_REV_REG, rawData) != NO_ERROR);
 
@@ -800,7 +800,7 @@ void setEncoderStepOffset(double offset) {
 
 // Set encoder zero point
 void zeroEncoder() {
-    
+
     // This function cannot be interrupted
     disableInterrupts();
 

--- a/src/hardware/motor.cpp
+++ b/src/hardware/motor.cpp
@@ -10,6 +10,11 @@
 // Main constructor
 StepperMotor::StepperMotor() {
 
+    // Setup step signal pins
+    pinMode(STEP_PIN, INPUT_PULLUP);
+    pinMode(ENABLE_PIN, INPUT);
+    pinMode(DIRECTION_PIN, INPUT);
+
     // Setup the pins as outputs
     pinMode(COIL_A_POWER_OUTPUT_PIN, OUTPUT);
     pinMode(COIL_B_POWER_OUTPUT_PIN, OUTPUT);

--- a/src/hardware/timers.cpp
+++ b/src/hardware/timers.cpp
@@ -55,9 +55,6 @@ void setupMotorTimers() {
     // - 1.0 - position correction (or PID interval update)
     // - 1.1 - PID correctional movement
 
-    // Setup the step and stallfault pin
-    pinMode(STEP_PIN, INPUT_PULLDOWN);
-
     // Check if StallFault is enabled
     #ifdef ENABLE_STALLFAULT
 

--- a/src/user/main.cpp
+++ b/src/user/main.cpp
@@ -53,6 +53,8 @@ void setup() {
     // Update the system clock with the new speed
     SystemCoreClockUpdate();
 
+    initDriverInputs();
+
     // Initialize the encoder
     initEncoder();
 
@@ -260,4 +262,10 @@ void blink() {
     delay(500);
     GPIO_WRITE(LED_PIN, LOW);
     delay(500);
+}
+
+void initDriverInputPins() {
+    pinMode(STEP_PIN, INPUT);
+    pinMode(ENABLE_PIN, INPUT);
+    pinMode(DIRECTION_PIN, INPUT);
 }

--- a/src/user/main.cpp
+++ b/src/user/main.cpp
@@ -53,7 +53,7 @@ void setup() {
     // Update the system clock with the new speed
     SystemCoreClockUpdate();
 
-    initDriverInputs();
+    initDriverInputPins();
 
     // Initialize the encoder
     initEncoder();

--- a/src/user/main.cpp
+++ b/src/user/main.cpp
@@ -53,8 +53,6 @@ void setup() {
     // Update the system clock with the new speed
     SystemCoreClockUpdate();
 
-    initDriverInputPins();
-
     // Initialize the encoder
     initEncoder();
 
@@ -262,10 +260,4 @@ void blink() {
     delay(500);
     GPIO_WRITE(LED_PIN, LOW);
     delay(500);
-}
-
-void initDriverInputPins() {
-    pinMode(STEP_PIN, INPUT);
-    pinMode(ENABLE_PIN, INPUT);
-    pinMode(DIRECTION_PIN, INPUT);
 }

--- a/src/user/main.h
+++ b/src/user/main.h
@@ -13,6 +13,4 @@ void loop();
 
 void blink();
 
-void initDriverInputPins();
-
 #endif

--- a/src/user/main.h
+++ b/src/user/main.h
@@ -6,15 +6,13 @@
 #include "config.h"
 #include "motor.h"
 
-//extern void Output(int32_t theta,uint8_t effort);
-//extern uint16_t ReadAngle(void);
-extern void overclock(uint32_t PLLMultiplier);
-
 extern StepperMotor motor;
 
-extern void setup();
-extern void loop();
+void setup();
+void loop();
 
-extern void blink();
+void blink();
+
+void initDriverInputPins();
 
 #endif


### PR DESCRIPTION
1)
```
 pinMode(STEP_PIN, INPUT_PULLDOWN);
```
PULLDOWN is wrong according to 
https://github.com/CAP1Sup/Intellistep/pull/50#discussion_r663051004
Note: INPUT_PULLUP is possible in this schematic.

2) ENABLE_PIN and DIRECTION_PIN were not initialized.
I don't know why DIRECTION_PIN worked before without initialization.
