### PR TITLE
Encoder speedup 1

### DIFF
--- a/src/hardware/encoder.cpp
+++ b/src/hardware/encoder.cpp
@@ -191,7 +191,7 @@ Encoder::Encoder() {
 errorTypes Encoder::readRegister(uint16_t registerAddress, uint16_t &data) {
 
     // Disable interrupts
-    disableMotorTimers();
+    disableInterrupts();
 
     // Create an accumulator for error checking
     errorTypes error = NO_ERROR;
@@ -246,7 +246,7 @@ errorTypes Encoder::readRegister(uint16_t registerAddress, uint16_t &data) {
     }
 
     // All done, we can re-enable interrupts
-    enableMotorTimers();
+    enableInterrupts();
 
     // Return error
     return error;
@@ -298,7 +298,7 @@ void Encoder::readMultipleRegisters(uint16_t registerAddress, uint16_t* data, ui
 void Encoder::writeToRegister(uint16_t registerAddress, uint16_t data) {
 
     // Disable the motor timers
-    disableMotorTimers();
+    disableInterrupts();
 
     // Pull CS low to select encoder
     GPIO_WRITE(ENCODER_CS_PIN, LOW);
@@ -328,7 +328,7 @@ void Encoder::writeToRegister(uint16_t registerAddress, uint16_t data) {
     GPIO_WRITE(ENCODER_CS_PIN, HIGH);
 
     // Re-enable the motor timers
-    enableMotorTimers();
+    enableInterrupts();
 }
 
 
@@ -425,7 +425,7 @@ uint8_t Encoder::calcCRC(uint8_t *data, uint8_t length) {
 void Encoder::resetSafety() {
 
     // Disable the motor timers
-    disableMotorTimers();
+    disableInterrupts();
 
     // Build the command
 	uint16_t command = ENCODER_READ_COMMAND + SAFE_HIGH;
@@ -445,7 +445,7 @@ void Encoder::resetSafety() {
     HAL_SPI_TransmitReceive(&spiConfig, txbuf, rxbuf, 2, 10);
 
     // Re-enable the motor timers
-    enableMotorTimers();
+    enableInterrupts();
 }
 
 

--- a/src/hardware/encoder.cpp
+++ b/src/hardware/encoder.cpp
@@ -167,7 +167,7 @@ Encoder::Encoder() {
 
     // Populate the average angle reading table
     for (uint8_t index = 0; index < ANGLE_AVG_READINGS; index++) {
-        getAngle();
+        getAngleAvg();
     }
 
     // Set the offsets
@@ -505,9 +505,14 @@ double Encoder::getRawAngle(bool average) {
     }
 }
 
-// Reads the value for the angle of the encoder (ranges from 0-360)
-double Encoder::getAngle(bool average) {
-    return (getRawAngle(average) - startupAngleOffset);
+// Reads the momentary value for the angle of the encoder (ranges from 0-360)
+double Encoder::getAngleNow() {
+    return (getRawAngle(false) - startupAngleOffset);
+}
+
+// Reads the average value for the angle of the encoder (ranges from 0-360)
+double Encoder::getAngleAvg() {
+    return (getRawAngle() - startupAngleOffset);
 }
 
 // For average velocity calculations instead of hardware readings from the TLE5012
@@ -720,7 +725,7 @@ double Encoder::getRev() {
 double Encoder::getAbsoluteAngle() {
 
     // Perform actual averaging
-    encoderAbsoluteAngleAvg.add((getRev() * 360) + getAngle(false));
+    encoderAbsoluteAngleAvg.add((getRev() * 360) + getAngleNow());
 
     // Return the average
     return encoderAbsoluteAngleAvg.get();

--- a/src/hardware/encoder.h
+++ b/src/hardware/encoder.h
@@ -279,7 +279,8 @@ class Encoder {
 
         // High level encoder functions
         double getRawAngle(bool average = true);
-        double getAngle(bool average = true);
+        double getAngleNow();
+        double getAngleAvg();
         double getSpeed();
         double getAccel();
         double getTemp();

--- a/src/hardware/encoder.h
+++ b/src/hardware/encoder.h
@@ -278,7 +278,8 @@ class Encoder {
         void resetSafety();
 
         // High level encoder functions
-        double getRawAngle(bool average = true);
+        double getRawAngleNow();
+        double getRawAngleAvg();
         double getAngleNow();
         double getAngleAvg();
         double getSpeed();

--- a/src/hardware/flash.cpp
+++ b/src/hardware/flash.cpp
@@ -86,7 +86,7 @@ float readFlashFloat(uint32_t parameterIndex) {
 void writeToFlashAddress(uint32_t address, uint16_t data) {
 
     // Disable the motor timers
-    disableMotorTimers();
+    disableInterrupts();
 
     // Unlock the flash for writing
     HAL_FLASH_Unlock();
@@ -101,7 +101,7 @@ void writeToFlashAddress(uint32_t address, uint16_t data) {
     HAL_FLASH_Lock();
 
     // Enable the motor timers
-    enableMotorTimers();
+    enableInterrupts();
 }
 
 
@@ -160,7 +160,7 @@ void writeFlash(uint32_t parameterIndex, float data) {
 void eraseParameters() {
 
     // Disable the motor timers
-    disableMotorTimers();
+    disableInterrupts();
 
     // Unlock the flash
     HAL_FLASH_Unlock();
@@ -184,7 +184,7 @@ void eraseParameters() {
     writeFlash(FLASH_CONTENTS_PATCH_VERSION_INDEX, PATCH_VERSION);
 
     // Re-enable the motor timers
-    setupMotorTimers();
+    enableInterrupts();
 }
 
 

--- a/src/hardware/motor.cpp
+++ b/src/hardware/motor.cpp
@@ -606,7 +606,7 @@ void StepperMotor::calibrate() {
     delay(3000);
 
     // Disable the motor timers (the motor needs to be left alone during calibration)
-    disableMotorTimers();
+    disableInterrupts();
 
     // Set the coils of the motor to move to step 0 (meaning the separation between full steps)
     driveCoils(0);

--- a/src/hardware/motor.cpp
+++ b/src/hardware/motor.cpp
@@ -525,10 +525,10 @@ void StepperMotor::setState(MOTOR_STATE newState, bool clearErrors) {
                 case ENABLED:
 
                     // Drive the coils the current angle of the shaft (just locks the output in place)
-                    driveCoilsAngle(encoder.getRawAngle());
+                    driveCoilsAngle(encoder.getRawAngleAvg());
 
                     // The motor's current angle needs corrected
-                    currentAngle = encoder.getRawAngle();
+                    currentAngle = encoder.getRawAngleAvg();
                     this -> state = ENABLED;
                     break;
 
@@ -536,10 +536,10 @@ void StepperMotor::setState(MOTOR_STATE newState, bool clearErrors) {
                 case FORCED_ENABLED:
 
                     // Drive the coils the current angle of the shaft (just locks the output in place)
-                    driveCoilsAngle(encoder.getRawAngle());
+                    driveCoilsAngle(encoder.getRawAngleAvg());
 
                     // The motor's current angle needs corrected
-                    currentAngle = encoder.getRawAngle();
+                    currentAngle = encoder.getRawAngleAvg();
                     this -> state = FORCED_ENABLED;
                     break;
 
@@ -562,10 +562,10 @@ void StepperMotor::setState(MOTOR_STATE newState, bool clearErrors) {
                     case ENABLED:
 
                         // Drive the coils the current angle of the shaft (just locks the output in place)
-                        driveCoilsAngle(encoder.getRawAngle());
+                        driveCoilsAngle(encoder.getRawAngleAvg());
 
                         // The motor's current angle needs corrected
-                        currentAngle = encoder.getRawAngle();
+                        currentAngle = encoder.getRawAngleAvg();
                         this -> state = ENABLED;
                         break;
 
@@ -619,11 +619,11 @@ void StepperMotor::calibrate() {
     for (uint8_t readings = 0; readings < (ANGLE_AVG_READINGS * 2); readings++) {
 
         // Get the angle, then wait for 10ms to allow encoder to update
-        encoder.getRawAngle();
+        encoder.getRawAngleAvg();
     }
 
     // Measure encoder offset
-    float stepOffset = encoder.getRawAngle();
+    float stepOffset = encoder.getRawAngleAvg();
 
     // Add/subtract the full step angle till the rawStepOffset is within the range of a full step
     while (stepOffset < 0) {

--- a/src/user/config.h
+++ b/src/user/config.h
@@ -18,7 +18,7 @@
     //#define ENABLE_BLINK
     //#define CHECK_STEPPING_RATE
     //#define CHECK_CORRECT_MOTOR_RATE
-    #define CHECK_ENCODER_SPEED
+    //#define CHECK_ENCODER_SPEED
 
     #if defined(ENABLE_BLINK) && defined(CHECK_STEPPING_RATE) && defined(CHECK_CORRECT_MOTOR_RATE) && defined(CHECK_ENCODER_SPEED)
         #error Only one of #define is possible at a time in this section

--- a/src/user/main.cpp
+++ b/src/user/main.cpp
@@ -60,7 +60,7 @@ void setup() {
     #ifdef CHECK_ENCODER_SPEED
         while(true) {
             GPIO_WRITE(LED_PIN, HIGH);
-            motor.encoder.getRawAngle();
+            motor.encoder.getRawAngleAvg();
             GPIO_WRITE(LED_PIN, LOW);
             delayMicroseconds(1);
         }


### PR DESCRIPTION
35kHz

This PR reduces a cyclomatic complexity.
https://medium.com/@amlcurran/clean-code-the-curse-of-a-boolean-parameter-c237a830b7a3

Here removes the **average** parameter from the XXX(bool average) functions.
**average** parameter doesn't need in fact.
**average** parameter always a constant, not a variable.
Not like **angle** in sin(angle) function.
**average** works like the
```
if(average){
   XXXAvg()
} else {
   XXXNow()
}
```
When you call XXX(bool average) function 
in src/hardware/motor.cpp or src/user/main.cpp, 
you always know in advance what you want (XXX(true) or XXX(false)) and should call XXXAvg() or XXXNow().

Ready to merge. I am not rushing you.
