### PR TITLE
Microsteps

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -162,7 +162,7 @@
 
 // If the motor should maintain a full stepping when the microstepping is different
 // This allows the motor to run in full step mode, while running quieter
-//#define MAINTAIN_FULL_STEPPING
+#define MAINTAIN_FULL_STEPPING
 
 // Stallfault
 //#define ENABLE_STALLFAULT

--- a/src/hardware/motor.h
+++ b/src/hardware/motor.h
@@ -306,7 +306,7 @@ class StepperMotor {
 
         // Index points multiplier
         // Indicates how many points will be skipped in the sine wave during one input step on the STEP pin
-        #ifdef MAINTAIN_FULL_STEP
+        #ifdef MAINTAIN_FULL_STEPPING
         uint32_t indexPointsMultiplier = 32;
         #endif
 

--- a/src/software/fastSine.cpp
+++ b/src/software/fastSine.cpp
@@ -52,4 +52,13 @@ const int16_t sineTable[SINE_VAL_COUNT] = {
 In 1/32 microstep mode,  every sine wave index point is used. (0, 1, 2, ..., 127, 128==0, ...)
 In full step mode, only 4 index points of  sine wave are used. (0, 1/2 pi, pi, 3/2pi, 2pi, ...) == (0, 32, 64, 96, 128==0, ...)
 The rest of the modes are in between them.
+
+Microstep  |Frequency of input | Shaft, | Number of input | Number of shaft
+divider    | pulses, Hz        |   RPM      | pulses          | rotations
+      1    |        200        |    60  |     200 * N     |     N
+      2    |        400        |    60  |     400 * N     |     N
+      4    |        800        |    60  |     800 * N     |     N
+      8    |       1600        |    60  |    1600 * N     |     N
+     16    |       3200        |    60  |    3200 * N     |     N
+     32    |       6400        |    60  |    6400 * N     |     N
 */

--- a/src/software/fastSine.cpp
+++ b/src/software/fastSine.cpp
@@ -54,7 +54,7 @@ In full step mode, only 4 index points of  sine wave are used. (0, 1/2 pi, pi, 3
 The rest of the modes are in between them.
 
 Microstep  |Frequency of input | Shaft, | Number of input | Number of shaft
-divider    | pulses, Hz        |   RPM      | pulses          | rotations
+divider    | pulses, Hz        |   RPM  | pulses          | rotations
       1    |        200        |    60  |     200 * N     |     N
       2    |        400        |    60  |     400 * N     |     N
       4    |        800        |    60  |     800 * N     |     N


### PR DESCRIPTION
DIP switches do not affect rotation speed and step resolution of the motor if
#define MAINTAIN_FULL_STEPPING is commented.

MAINTAIN_FULL_STEPPING not needed at all.