### PR TITLE
Motor Stepping Speedups (Removal of CW and CWW)

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -115,7 +115,7 @@
 
 // PID settings
 // ! At this time, this feature is still under development
-//#define ENABLE_PID
+#define ENABLE_PID
 #ifdef ENABLE_PID
 
     // Default P, I, and D terms

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -137,7 +137,7 @@
 #endif
 
 // Direct step functionality (used to command motor to move over Serial/CAN)
-//#define ENABLE_DIRECT_STEPPING
+#define ENABLE_DIRECT_STEPPING
 #ifdef ENABLE_DIRECT_STEPPING
 
     // The default stepping rate (in Hz) to move in the event that no parameter is specified

--- a/src/hardware/motor.cpp
+++ b/src/hardware/motor.cpp
@@ -517,6 +517,7 @@ void StepperMotor::step(STEP_DIR dir, bool useMultiplier, bool updateDesiredPos)
         stepChange = (this -> microstepMultiplier);
     }
 
+    /*
     // Invert the change based on the direction
     if (dir == PIN) {
 
@@ -531,6 +532,7 @@ void StepperMotor::step(STEP_DIR dir, bool useMultiplier, bool updateDesiredPos)
         // Make the step change in the negative direction
         stepChange = -stepChange;
     }
+    */
 
     #ifdef ENABLE_STEPPING_VELOCITY
         isStepping = false;
@@ -545,8 +547,9 @@ void StepperMotor::step(STEP_DIR dir, bool useMultiplier, bool updateDesiredPos)
     }
     #endif
 
+    // Invert the change based on the direction
     // Only moving one step in the specified direction
-    this -> currentStep += stepChange;
+    this -> currentStep += stepChange * dir * (this -> reversed);
 
     // Drive the coils to their destination
     this -> driveCoils(this -> currentStep);

--- a/src/hardware/motor.cpp
+++ b/src/hardware/motor.cpp
@@ -423,10 +423,10 @@ void StepperMotor::setReversed(bool reversed) {
 
     // Set if the motor should be reversed
     if (reversed) {
-        this -> reversed = -1;
+        this -> reversed = NEGATIVE;
     }
     else {
-        this -> reversed = 1;
+        this -> reversed = POSITIVE;
     }
 }
 

--- a/src/hardware/motor.h
+++ b/src/hardware/motor.h
@@ -292,7 +292,7 @@ class StepperMotor {
         // reversed is a multiplier for steps and angles
         // 1 - If the motor direction is normal
         // -1 - If the motor direction is inverted
-        int reversed = 1;
+        STEP_DIR reversed = 1;
 
         // If the motor enable is inverted
         bool enableInverted = false;

--- a/src/hardware/motor.h
+++ b/src/hardware/motor.h
@@ -28,15 +28,11 @@ typedef enum {
     COAST
 } COIL_STATE;
 
-// Enumeration for stepping direction
-/*
-typedef enum {
-    PIN,
-    COUNTER_CLOCKWISE,
-    CLOCKWISE
-} STEP_DIR;
-*/
-typedef int STEP_DIR; // only -1-negative and 1-positive are possible values
+ // Enumeration for stepping direction
+ typedef enum {
+     NEGATIVE = -1,
+     POSITIVE = 1
+ } STEP_DIR;
 
 // Enumeration for the enable state of the motor
 typedef enum {
@@ -292,7 +288,7 @@ class StepperMotor {
         // reversed is a multiplier for steps and angles
         // 1 - If the motor direction is normal
         // -1 - If the motor direction is inverted
-        STEP_DIR reversed = 1;
+        STEP_DIR reversed = POSITIVE;
 
         // If the motor enable is inverted
         bool enableInverted = false;

--- a/src/hardware/motor.h
+++ b/src/hardware/motor.h
@@ -29,11 +29,14 @@ typedef enum {
 } COIL_STATE;
 
 // Enumeration for stepping direction
+/*
 typedef enum {
     PIN,
     COUNTER_CLOCKWISE,
     CLOCKWISE
 } STEP_DIR;
+*/
+typedef int STEP_DIR; // only -1-negative and 1-positive are possible values
 
 // Enumeration for the enable state of the motor
 typedef enum {
@@ -186,9 +189,9 @@ class StepperMotor {
 
         // Calculates the coil values for the motor and updates the set angle.
         #ifdef USE_HARDWARE_STEP_CNT
-        void step(STEP_DIR dir = PIN, bool useMultiplier = true);
+        void step(STEP_DIR dir, bool useMultiplier = true);
         #else
-        void step(STEP_DIR dir = PIN, bool useMultiplier = true, bool updateDesiredPos = true);
+        void step(STEP_DIR dir, bool useMultiplier = true, bool updateDesiredPos = true);
         #endif
 
         // Sets the coils to hold the motor at the desired step number
@@ -289,11 +292,7 @@ class StepperMotor {
         // reversed is a multiplier for steps and angles
         // 1 - If the motor direction is normal
         // -1 - If the motor direction is inverted
-        #ifdef DIR_PIN_REVERSED
-        int8_t reversed = -1;
-        #else
-        int8_t reversed = 1;
-        #endif
+        int reversed = 1;
 
         // If the motor enable is inverted
         bool enableInverted = false;

--- a/src/hardware/timers.cpp
+++ b/src/hardware/timers.cpp
@@ -50,7 +50,7 @@ static uint8_t interruptBlockCount = 0;
     HardwareTimer *stepScheduleTimer = new HardwareTimer(TIM4);
 
     // Direction of movement for direct steps
-    STEP_DIR scheduledStepDir = COUNTER_CLOCKWISE;
+    STEP_DIR scheduledStepDir = 1;
 
     // Remaining step count
     int64_t remainingScheduledSteps = 0;
@@ -252,7 +252,7 @@ void stepMotor() {
     #endif
 
     // Step the motor
-    motor.step();
+    motor.step(DIRECTION(GPIO_READ(DIRECTION_PIN)));
 
     #ifdef CHECK_STEPPING_RATE
         GPIO_WRITE(LED_PIN, LOW);
@@ -315,10 +315,10 @@ void correctMotor() {
                 else {
                     // Set the direction
                     if (pidOutput > 0) {
-                        scheduledStepDir = COUNTER_CLOCKWISE;
+                        scheduledStepDir = 1;
                     }
                     else {
-                        scheduledStepDir = CLOCKWISE;
+                        scheduledStepDir = -1;
                     }
 
                     // Set that we don't want to decrement the counter
@@ -362,18 +362,18 @@ void correctMotor() {
                         // Motor is at a position larger than the desired one
                         // Use the current angle to find the current step, then subtract 1
                         #ifdef USE_HARDWARE_STEP_CNT
-                            motor.step(CLOCKWISE, false);
+                            motor.step(-1, false);
                         #else
-                            motor.step(CLOCKWISE, false, false);
+                            motor.step(-1, false, false);
                         #endif
                     }
                     else {
                         // Motor is at a position smaller than the desired one
                         // Use the current angle to find the current step, then add 1
                         #ifdef USE_HARDWARE_STEP_CNT
-                            motor.step(COUNTER_CLOCKWISE, false);
+                            motor.step(1, false);
                         #else
-                            motor.step(COUNTER_CLOCKWISE, false, false);
+                            motor.step(1, false, false);
                         #endif
                     }
                 }

--- a/src/hardware/timers.cpp
+++ b/src/hardware/timers.cpp
@@ -315,10 +315,10 @@ void correctMotor() {
                 else {
                     // Set the direction
                     if (pidOutput > 0) {
-                        scheduledStepDir = 1;
+                        scheduledStepDir = POSITIVE;
                     }
                     else {
-                        scheduledStepDir = -1;
+                        scheduledStepDir = NEGATIVE;
                     }
 
                     // Set that we don't want to decrement the counter

--- a/src/hardware/timers.cpp
+++ b/src/hardware/timers.cpp
@@ -50,7 +50,7 @@ static uint8_t interruptBlockCount = 0;
     HardwareTimer *stepScheduleTimer = new HardwareTimer(TIM4);
 
     // Direction of movement for direct steps
-    STEP_DIR scheduledStepDir = 1;
+    STEP_DIR scheduledStepDir = POSITIVE;
 
     // Remaining step count
     int64_t remainingScheduledSteps = 0;
@@ -252,7 +252,7 @@ void stepMotor() {
     #endif
 
     // Step the motor
-    motor.step(DIRECTION(GPIO_READ(DIRECTION_PIN)));
+    motor.step((STEP_DIR)DIRECTION(GPIO_READ(DIRECTION_PIN)));
 
     #ifdef CHECK_STEPPING_RATE
         GPIO_WRITE(LED_PIN, LOW);
@@ -362,18 +362,18 @@ void correctMotor() {
                         // Motor is at a position larger than the desired one
                         // Use the current angle to find the current step, then subtract 1
                         #ifdef USE_HARDWARE_STEP_CNT
-                            motor.step(-1, false);
+                            motor.step(NEGATIVE, false);
                         #else
-                            motor.step(-1, false, false);
+                            motor.step(NEGATIVE, false, false);
                         #endif
                     }
                     else {
                         // Motor is at a position smaller than the desired one
                         // Use the current angle to find the current step, then add 1
                         #ifdef USE_HARDWARE_STEP_CNT
-                            motor.step(1, false);
+                            motor.step(POSITIVE, false);
                         #else
-                            motor.step(1, false, false);
+                            motor.step(POSITIVE, false, false);
                         #endif
                     }
                 }

--- a/src/software/parser.cpp
+++ b/src/software/parser.cpp
@@ -409,10 +409,10 @@ String parseCommand(String buffer) {
 
                 // Call the steps to be scheduled
                 if (!reverse) {
-                    scheduleSteps(count, rate, 1);
+                    scheduleSteps(count, rate, POSITIVE);
                 }
                 else {
-                    scheduleSteps(count, rate, -1);
+                    scheduleSteps(count, rate, NEGATIVE);
                 }
 
                 // All good, we can exit

--- a/src/software/parser.cpp
+++ b/src/software/parser.cpp
@@ -409,10 +409,10 @@ String parseCommand(String buffer) {
 
                 // Call the steps to be scheduled
                 if (!reverse) {
-                    scheduleSteps(count, rate, COUNTER_CLOCKWISE);
+                    scheduleSteps(count, rate, 1);
                 }
                 else {
-                    scheduleSteps(count, rate, CLOCKWISE);
+                    scheduleSteps(count, rate, -1);
                 }
 
                 // All good, we can exit


### PR DESCRIPTION
https://github.com/CAP1Sup/Intellistep/blob/f292d5d595b82d5efa1879fca8f6c93d19482ed4/src/hardware/motor.h#L31-L37
1) PIN definition is not required. 
Simply detect direction in timers.cpp before the call of motor.step() and send it as +1 or -1 (it will be used as multiplier) to the
```
 motor.step(DIRECTION(GPIO_READ(DIRECTION_PIN)));
```
2) COUNTER_CLOCKWISE & CLOCKWISE are excessive. 
They lead to an  additional layer of abstraction. They depend on the position of the observer (You can look in front or back side of the motor). Aslo, you must to remember allwaiys that COUNTER_CLOCKWISE is positive and CLOCKWISE is negative direction. In real, they are inconvenient to describe positive and negative direction of the counters.
+1 and -1 is ideal to define a direction.

3) On a 32-bit system, int (int32_t) is faster than int8_t and int61_t because the compiler doesn't execute sign propagation. We win the speed(a little bit) and lose some bytes.
