### PR TITLE
Speedup7 (Restore 91.2kHz)

### DIFF
--- a/src/hardware/motor.h
+++ b/src/hardware/motor.h
@@ -28,7 +28,7 @@ typedef enum {
     COAST
 } COIL_STATE;
 
-#if 0
+#if 1
     // 89.9kHz
     // Enumeration for stepping direction
     typedef enum {

--- a/src/hardware/motor.h
+++ b/src/hardware/motor.h
@@ -28,11 +28,19 @@ typedef enum {
     COAST
 } COIL_STATE;
 
- // Enumeration for stepping direction
- typedef enum {
-     NEGATIVE = -1,
-     POSITIVE = 1
- } STEP_DIR;
+#if 0
+    // 89.9kHz
+    // Enumeration for stepping direction
+    typedef enum {
+        NEGATIVE = -1,
+        POSITIVE = 1
+    } STEP_DIR;
+#else
+    // 91.17kHz
+    #define         NEGATIVE (-1)
+    #define         POSITIVE 1
+    typedef int32_t STEP_DIR;
+#endif
 
 // Enumeration for the enable state of the motor
 typedef enum {
@@ -280,7 +288,7 @@ class StepperMotor {
         int32_t microstepsPerRotation = (360.0 / getMicrostepAngle());
 
         // Step to sine array conversion
-        uint8_t stepToSineArrayFactor = MAX_MICROSTEP_DIVISOR / getMicrostepping();
+        int32_t stepToSineArrayFactor = MAX_MICROSTEP_DIVISOR / getMicrostepping();
 
         // If the motor is enabled or not (saves time so that the enable and disable pins are only set once)
         MOTOR_STATE state = MOTOR_NOT_SET;

--- a/src/software/macros.h
+++ b/src/software/macros.h
@@ -9,7 +9,7 @@
 #define POWER_2(N) (1U << (N))
 
 // Extend the motor steps range to the encoder increment range
-#define MOTOR_STEP_TO_ENCODER_INCREMENT(steps, stepsPerRev, microstepDivisor) ( (steps) * ((POW_2_15) >> (REJECT_ENCODERS_LSB)) / ((stepsPerRev) * (microstepDivisor)) )
+//#define MOTOR_STEP_TO_ENCODER_INCREMENT(steps, stepsPerRev, microstepDivisor) ( (steps) * ((POW_2_15) >> (REJECT_ENCODERS_LSB)) / ((stepsPerRev) * (microstepDivisor)) )
 
 // Bitwise memory modification - ARM bitband
 #define BITBAND(addr, bitnum) ((addr & 0xF0000000)+0x2000000+((addr &0xFFFFF)<<5)+(bitnum<<2))


### PR DESCRIPTION
It is not obviously, but:
The stepToSineArrayFactor should be the signed type to use in signed formula.
The STEP_DIR type convertation has matter also.

I used to read these rules somewhere:
-use [u]intXX_t to access to hardware reg's or define API interfaces(also files, databases)
-use [u]int for fastest execution(compiler will use full size register without sign propagation)
-don't mix signed and unsigned types

Some info here also https://stackoverflow.com/questions/36161393/is-there-a-reason-to-use-c11s-stdint-fast32-t-or-stdint-fast16-t-over-int
