### PR TITLE
Set priority grouping explicitly to 3.1(PRIO.SUBPRIO)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -27,7 +27,7 @@ build_flags = -fmax-errors=5
 	-Wall
 	#-save-temps # save prepprocessing files .i, .ii, .s // comment out this line for faster compilation
 
-	# Set the priority for external interrupts (set to zero for step interrupt)
+	# Set the priority for external interrupts (for STEP pin interrupt)
 	-D EXTI_IRQ_PRIO=6
 	-D EXTI_IRQ_SUBPRIO=0
 

--- a/src/hardware/motor.cpp
+++ b/src/hardware/motor.cpp
@@ -27,7 +27,7 @@ StepperMotor::StepperMotor() {
     HAL_TIM_Base_Init(&tim2Config);
 
     // Set that the step pin should be an external trigger for the timer to count
-    tim2ClkConfig.ClockFilter = 7;
+    tim2ClkConfig.ClockFilter = 0;
     tim2ClkConfig.ClockPolarity = TIM_CLOCKPOLARITY_INVERTED;
     tim2ClkConfig.ClockPrescaler = TIM_CLOCKPRESCALER_DIV1;
     tim2ClkConfig.ClockSource = TIM_CLOCKSOURCE_ETRMODE2;

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -22,7 +22,7 @@ void setup() {
     SystemInit();
 
     // Set priority groupping explicitly to 3.1(PRIO.SUBPRIO)
-    // Possible value for PRIO fom 0 to 7 and for SUBPRIO fom 0 to 1 in setInterruptPriority()
+    // Possible value for PRIO from 0 to 7 and for SUBPRIO from 0 to 1 in setInterruptPriority()
     NVIC_SetPriorityGrouping(3);
 
     // Configure the system clock

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -21,6 +21,10 @@ void setup() {
     // Set processor up
     SystemInit();
 
+    // Set priority groupping explicitly to 3.1(PRIO.SUBPRIO)
+    // Possible value for PRIO fom 0 to 7 and for SUBPRIO fom 0 to 1 in setInterruptPriority()
+    NVIC_SetPriorityGrouping(3);
+
     // Configure the system clock
     #if defined(SYSCLK_SRC_HSE_16)
         #if SYSCLK_FREQ == 72

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -21,7 +21,7 @@ void setup() {
     // Set processor up
     SystemInit();
 
-    // Set priority groupping explicitly to 3.1(PRIO.SUBPRIO)
+    // Set priority grouping explicitly to 3.1(PRIO.SUBPRIO)
     // Possible value for PRIO from 0 to 7 and for SUBPRIO from 0 to 1 in setInterruptPriority()
     NVIC_SetPriorityGrouping(3);
 


### PR DESCRIPTION
1)Set STEP input filter to 0
2)Set priority grouping explicitly to 3.1(PRIO.SUBPRIO)
Default priority grouping is 2.2 
